### PR TITLE
Use require.resolve to get original template path

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,10 +1,13 @@
 var Hogan = require('hogan.js'),
     fs = require('fs'),
+    util = require('util'),
     path = require('path'),
     govukConfig = require('./config'),
     compiledTemplate,
     govukTemplate;
 
-govukTemplate = fs.readFileSync( path.resolve( __dirname, '../node_modules/govuk_template_mustache/views/layouts/govuk_template.html' ), { encoding : 'utf-8' });
+var template = require.resolve('govuk_template_mustache/views/layouts/govuk_template.html');
+
+govukTemplate = fs.readFileSync(template, { encoding : 'utf-8' });
 compiledTemplate = Hogan.compile(govukTemplate);
-fs.writeFileSync( path.resolve( __dirname, '../govuk_template.html' ), compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+fs.writeFileSync(path.resolve(__dirname, '../govuk_template.html'), compiledTemplate.render(govukConfig), { encoding : 'utf-8' });

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var path = require('path'),
     servestatic = require('serve-static');
 
+var basedir = path.dirname(require.resolve('govuk_template_mustache/package.json'));
+
 module.exports = {
     setup: function (app, options) {
 
         options = options || {};
         options.path = options.path || '/govuk-assets';
 
-        app.use(options.path, servestatic(path.join(__dirname, './node_modules/govuk_template_mustache/assets'), options));
+        app.use(options.path, servestatic(path.join(basedir, './assets'), options));
         app.use(function (req, res, next) {
             res.locals.govukAssetPath = options.path + '/';
             res.locals.partials = res.locals.partials || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-govuk-template",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Compile govuk mustache template into a more usable format and provide middleware for use in apps",
   "scripts": {
     "postinstall": "node ./build/index.js"


### PR DESCRIPTION
It's not necessarily the case that the module is being resolved from the local ./node_modules folder. Use require resolve to get the template path to cover cases where the template is actually installed in a different location.
