### PR TITLE
Include req.baseUrl is asset path

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
 
         app.use(options.path, servestatic(path.join(basedir, './assets'), options));
         app.use(function (req, res, next) {
-            res.locals.govukAssetPath = options.path + '/';
+            res.locals.govukAssetPath = req.baseUrl + options.path + '/';
             res.locals.partials = res.locals.partials || {};
             res.locals.partials['govuk-template'] = path.resolve(__dirname, './govuk_template');
             next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-govuk-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Compile govuk mustache template into a more usable format and provide middleware for use in apps",
   "scripts": {
     "postinstall": "node ./build/index.js"


### PR DESCRIPTION
If app is namespaced under another route then this needs to be taken into account when importing assets
