### PR TITLE
Expose asset path as a property on the module

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,6 @@ module.exports = {
             next();
         });
 
-    }
+    },
+    assetPath: path.join(basedir, './assets')
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-govuk-template",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Compile govuk mustache template into a more usable format and provide middleware for use in apps",
   "scripts": {
     "postinstall": "node ./build/index.js"


### PR DESCRIPTION
To allow parent dependencies to establish the location of the assets.
