### PR TITLE
separate identifying partial locations and the hosting of assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ It will also add the template as a mustache partial with a name of "govuk-templa
 require('hmpo-govuk-template').setup(app[, { ... options ...}]);
 ```
 
+### To only load the partial location but not serve the assets use the template function. The `govukAssetPath` local will need to set to the absolute public asset location.
+```
+app.use(function (req, res, next) {
+    res.locals = res.locals || {};
+    res.locals.govukAssetPath = '/absolute/asset/path'
+});
+app.use(require('hmpo-govuk-template').template);
+```
+
 ### To use the mustache partial
 ```
 {{< govuk-template}}

--- a/index.js
+++ b/index.js
@@ -3,20 +3,25 @@ var path = require('path'),
 
 var basedir = path.dirname(require.resolve('govuk_template_mustache/package.json'));
 
-module.exports = {
+var govuk = {
     setup: function (app, options) {
-
         options = options || {};
         options.path = options.path || '/govuk-assets';
 
         app.use(options.path, servestatic(path.join(basedir, './assets'), options));
         app.use(function (req, res, next) {
             res.locals.govukAssetPath = req.baseUrl + options.path + '/';
-            res.locals.partials = res.locals.partials || {};
-            res.locals.partials['govuk-template'] = path.resolve(__dirname, './govuk_template');
             next();
         });
 
+        app.use(govuk.template);
+    },
+    template: function (req, res, next) {
+        res.locals.partials = res.locals.partials || {};
+        res.locals.partials['govuk-template'] = path.resolve(__dirname, './govuk_template');
+        next();
     },
     assetPath: path.join(basedir, './assets')
 };
+
+module.exports = govuk;


### PR DESCRIPTION
Every time the govuk template partial location is wanted by using setup(app) the assets are also mounted with serve static on the current baseUrl.
This change allows access to the template partial without mounting the assets and forcing the asset location local to be the new location.
This allows assets to be hosted elsewhere (such as a CDN) by specifying the asset location local.