### PR TITLE
Wrap govuk logo in template to allow overriding

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -10,4 +10,9 @@ var template = require.resolve('govuk_template_mustache/views/layouts/govuk_temp
 
 govukTemplate = fs.readFileSync(template, { encoding : 'utf-8' });
 compiledTemplate = Hogan.compile(govukTemplate);
-fs.writeFileSync(path.resolve(__dirname, '../govuk_template.html'), compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+
+var renderedTemplate = compiledTemplate.render(govukConfig);
+var reHeaderLogo = new RegExp('(<img [^>]+gov.uk_logotype_crown_invert_trans.png[^>]+>)', 'i');
+renderedTemplate = renderedTemplate.replace(reHeaderLogo, '{{$globalHeaderImage}}$1{{/globalHeaderImage}}');
+
+fs.writeFileSync(path.resolve(__dirname, '../govuk_template.html'), renderedTemplate, { encoding : 'utf-8' });


### PR DESCRIPTION
The GOV.UK template provides a way to customise the header link text, link and alt text, but not to customise the logo image.
This PR uses a string replace to find the header image tag and wrap it with a template, so it uses the GOV.UK header image by default but can be overridden in any view.
This change should be fully backwards compatible.

NOTE: This only changes the black img tag that is only visible with no CSS enabled. The white image is specified in CSS and must be overridden with CSS